### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ hackerrank: build
 
 .PHONY: install
 install: build
-	cp "$(INCLUDE_DIR)/*" /usr/include
-	cp "$(LIB_DIR)/*" /usr/lib
+	cp "$(INCLUDE_DIR)/*" /usr/local/include
+	cp "$(LIB_DIR)/*" /usr/local/lib
 
 # TODO: add dependencies
 .PHONY: pacman


### PR DESCRIPTION
When library is copied directly to `/usr/include` and `/usr/lib` (lines 80 and 81) permission is denied on Mac systems (even when running as root) due to its [System Integrity Protection](https://developer.apple.com/library/content/documentation/Security/Conceptual/System_Integrity_Protection_Guide/ConfiguringSystemIntegrityProtection/ConfiguringSystemIntegrityProtection.html).