### PR TITLE
Makefile.macos and Homebrew compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 8.1.0
+VERSION := 8.1.1
 
 # soname - libcs50.so.<major_version>
 SONAME := libcs50.so.$(shell echo $(VERSION) | head -c 1)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 8.0.3
+VERSION := 8.1.0
 
 # soname - libcs50.so.<major_version>
 SONAME := libcs50.so.$(shell echo $(VERSION) | head -c 1)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 8.1.2
+VERSION := 8.1.3
 
 # soname - libcs50.so.<major_version>
 SONAME := libcs50.so.$(shell echo $(VERSION) | head -c 1)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 8.1.1
+VERSION := 8.1.2
 
 # soname - libcs50.so.<major_version>
 SONAME := libcs50.so.$(shell echo $(VERSION) | head -c 1)

--- a/Makefile.macos
+++ b/Makefile.macos
@@ -29,7 +29,6 @@ install: build docs
 	$(MAKE) -f Makefile.macos clean
 
 clean:
-	$(shell type -p git) clean -xfd
 	rm -rf $(BUILD_ROOT)
 
 uninstall: clean

--- a/Makefile.macos
+++ b/Makefile.macos
@@ -19,7 +19,7 @@ build: clean
 .PHONY: docs
 docs: clean
 	mkdir -p $(BUILD_DIR)/$(MAN_DIR)
-	asciidoctor -d manpage -b manpage -D $(BUILD_DIR)/$(MAN_DIR) docs/*.adoc
+	cp -R docs/man/ $(BUILD_DIR)/$(MAN_DIR)
 
 install: build docs
 	cp -R $(BUILD_ROOT) $(PREFIX)

--- a/Makefile.macos
+++ b/Makefile.macos
@@ -13,7 +13,7 @@ build: clean
 	mkdir -p $(BUILD_DIR)/include $(BUILD_DIR)/lib
 	cp src/cs50.h $(BUILD_DIR)/include/
 	ln -sf libcs50-$(VERSION).dylib libcs50-$(MAJOR_VERSION).dylib
-	ln -sf $(DLNAME) libcs50.dylib
+	ln -sf libcs50-$(MAJOR_VERSION).dylib libcs50.dylib
 	mv *.dylib $(BUILD_DIR)/lib/
 
 .PHONY: docs

--- a/Makefile.macos
+++ b/Makefile.macos
@@ -1,6 +1,5 @@
-VERSION := 8.0.3
+VERSION := 8.0.4
 MAJOR_VERSION := $(shell echo $(VERSION) | head -c 1)
-DLNAME := libcs50-$(MAJOR_VERSION).dylib
 
 PREFIX ?= /usr/local/Cellar
 BUILD_ROOT ?= libcs50
@@ -9,12 +8,12 @@ MAN_DIR ?= share/man/man3
 
 build: clean
 	$(CC) -c -fPIC -std=gnu99 -Wall -o cs50.o src/cs50.c
-	$(CC) -shared -Wl,-install_name,$(DLNAME) -o libcs50-$(VERSION).dylib cs50.o
+	$(CC) -shared -Wl,-install_name,libcs50-$(MAJOR_VERSION).dylib -o libcs50-$(VERSION).dylib cs50.o
 	rm cs50.o
 	mkdir -p $(BUILD_DIR)/include $(BUILD_DIR)/lib
 	cp src/cs50.h $(BUILD_DIR)/include/
-	ln -s libcs50-$(VERSION).dylib $(DLNAME)
-	ln -s $(DLNAME) libcs50.dylib
+	ln -sf libcs50-$(VERSION).dylib libcs50-$(MAJOR_VERSION).dylib
+	ln -sf $(DLNAME) libcs50.dylib
 	mv *.dylib $(BUILD_DIR)/lib/
 
 .PHONY: docs
@@ -24,11 +23,13 @@ docs: clean
 
 install: build docs
 	cp -R $(BUILD_ROOT) $(PREFIX)
-	ln -s $(PREFIX)/$(BUILD_DIR)/include/* /usr/local/include
-	ln -s $(PREFIX)/$(BUILD_DIR)/lib/* /usr/local/lib
-	ln -s $(PREFIX)/$(BUILD_DIR)/$(MAN_DIR)/* /usr/local/$(MAN_DIR)
+	ln -sf $(PREFIX)/$(BUILD_DIR)/include/* /usr/local/include
+	ln -sf $(PREFIX)/$(BUILD_DIR)/lib/* /usr/local/lib
+	ln -sf $(PREFIX)/$(BUILD_DIR)/$(MAN_DIR)/* /usr/local/$(MAN_DIR)
+	$(MAKE) -f Makefile.macos clean
 
 clean:
+	$(GIT) clean -xfd
 	rm -rf $(BUILD_ROOT)
 
 uninstall: clean

--- a/Makefile.macos
+++ b/Makefile.macos
@@ -29,7 +29,7 @@ install: build docs
 	$(MAKE) -f Makefile.macos clean
 
 clean:
-	$(GIT) clean -xfd
+	$(shell type -p git) clean -xfd
 	rm -rf $(BUILD_ROOT)
 
 uninstall: clean

--- a/Makefile.macos
+++ b/Makefile.macos
@@ -1,0 +1,39 @@
+VERSION := 8.0.3
+MAJOR_VERSION := $(shell echo $(VERSION) | head -c 1)
+DLNAME := libcs50-$(MAJOR_VERSION).dylib
+
+PREFIX ?= /usr/local/Cellar
+BUILD_ROOT ?= libcs50
+BUILD_DIR ?= $(BUILD_ROOT)/$(VERSION)
+MAN_DIR ?= share/man/man3
+
+build: clean
+	$(CC) -c -fPIC -std=gnu99 -Wall -o cs50.o src/cs50.c
+	$(CC) -shared -Wl,-install_name,$(DLNAME) -o libcs50-$(VERSION).dylib cs50.o
+	rm cs50.o
+	mkdir -p $(BUILD_DIR)/include $(BUILD_DIR)/lib
+	cp src/cs50.h $(BUILD_DIR)/include/
+	ln -s libcs50-$(VERSION).dylib $(DLNAME)
+	ln -s $(DLNAME) libcs50.dylib
+	mv *.dylib $(BUILD_DIR)/lib/
+
+.PHONY: docs
+docs: clean
+	mkdir -p $(BUILD_DIR)/$(MAN_DIR)
+	asciidoctor -d manpage -b manpage -D $(BUILD_DIR)/$(MAN_DIR) docs/*.adoc
+
+install: build docs
+	cp -R $(BUILD_ROOT) $(PREFIX)
+	ln -s $(PREFIX)/$(BUILD_DIR)/include/* /usr/local/include
+	ln -s $(PREFIX)/$(BUILD_DIR)/lib/* /usr/local/lib
+	ln -s $(PREFIX)/$(BUILD_DIR)/$(MAN_DIR)/* /usr/local/$(MAN_DIR)
+
+clean:
+	rm -rf $(BUILD_ROOT)
+
+uninstall: clean
+	rm -rf $(PREFIX)/$(BUILD_ROOT)
+	rm -f /usr/local/include/cs50.h
+	rm -f /usr/local/lib/libcs50*.dylib
+	rm -f /usr/local/share/man/man3/eprintf.3
+	rm -f /usr/local/share/man/man3/get_*.3

--- a/Makefile.macos
+++ b/Makefile.macos
@@ -1,4 +1,4 @@
-VERSION := 8.0.4
+VERSION := $(shell $(MAKE) version)
 MAJOR_VERSION := $(shell echo $(VERSION) | head -c 1)
 
 PREFIX ?= /usr/local/Cellar

--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ $ sudo apt-get update
 $ sudo apt-get install libcs50
 ```
 
-### From Source
+### macOS
+
+```
+$ brew install libcs50
+```
+
+### From Source (Ubuntu Only)
 
 1. Download the latest release per https://github.com/cs50/libcs50/releases
 1. Extract `libcs50-*.*`

--- a/docs/generate_man.sh
+++ b/docs/generate_man.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Translate the AsciiDoc source FILE or FILE(s) into the backend output format (e.g., HTML 5, DocBook 4.5, etc.)
+# Get asciidoctor at https://github.com/asciidoctor/asciidoctor
+# Alternately, since asciidoctor is a Ruby gem, you can just
+# `gem install asciidocs`
+
+asciidoctor -d manpage -b manpage -D ./man *.adoc

--- a/docs/man/eprintf.3
+++ b/docs/man/eprintf.3
@@ -1,0 +1,52 @@
+'\" t
+.\"     Title: eprintf
+.\"    Author: [see the "AUTHORS" section]
+.\" Generator: Asciidoctor 1.5.5
+.\"      Date: 2017-07-09
+.\"    Manual: CS50 Programmer's Manual
+.\"    Source: CS50
+.\"  Language: English
+.\"
+.TH "EPRINTF" "3" "2017-07-09" "CS50" "CS50 Programmer\(aqs Manual"
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.ss \n[.ss] 0
+.nh
+.ad l
+.de URL
+\\$2 \(laURL: \\$1 \(ra\\$3
+..
+.if \n[.g] .mso www.tmac
+.LINKSTYLE blue R < >
+.SH "NAME"
+eprintf \- prints an error message to stderr
+.SH "SYNOPSIS"
+.sp
+\fB#include <cs50.h>\fP
+.sp
+\fBvoid eprintf(const string format, ...);\fP
+.SH "DESCRIPTION"
+.sp
+Prints an error message, formatted like \fBprintf(3)\fP, to the standard error, prefixing it with file and line number from which the function was called. See \fBprintf(3)\fP for more on formatting.
+.SH "EXAMPLE"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+eprintf("%s\(rsn", "this is an error");
+.fi
+.if n \{\
+.RE
+.\}
+.SH "SEE ALSO"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+printf(3)
+.fi
+.if n \{\
+.RE
+.\}

--- a/docs/man/get_char.3
+++ b/docs/man/get_char.3
@@ -1,0 +1,71 @@
+'\" t
+.\"     Title: get_char
+.\"    Author: [see the "AUTHORS" section]
+.\" Generator: Asciidoctor 1.5.5
+.\"      Date: 2017-07-09
+.\"    Manual: CS50 Programmer's Manual
+.\"    Source: CS50
+.\"  Language: English
+.\"
+.TH "GET_CHAR" "3" "2017-07-09" "CS50" "CS50 Programmer\(aqs Manual"
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.ss \n[.ss] 0
+.nh
+.ad l
+.de URL
+\\$2 \(laURL: \\$1 \(ra\\$3
+..
+.if \n[.g] .mso www.tmac
+.LINKSTYLE blue R < >
+.SH "NAME"
+get_char \- prompts user for a line of text from stdin and returns the equivalent char
+.SH "SYNOPSIS"
+.sp
+\fB#include <cs50.h>\fP
+.sp
+\fBchar get_char(string prompt);\fP
+.SH "DESCRIPTION"
+.sp
+Prompts user for a line of text from standard input and returns the equivalent char; if text is not a single char, user is prompted to retry.
+.SH "RETURN VALUE"
+.sp
+Returns the equivalent char of the line read from stdin. If line can\(cqt be read, returns \fBCHAR_MAX\fP.
+.SH "EXAMPLE"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+// attempt to read character from stdin
+char c = get_char("Enter char: ");
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+// ensure character was read
+if (c != CHAR_MAX)
+{
+    printf("You entered: %c\(rsn", c);
+}
+.fi
+.if n \{\
+.RE
+.\}
+.SH "SEE ALSO"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+get_double(3), get_float(3), get_int(3), get_long_long(3),
+get_string(3)
+.fi
+.if n \{\
+.RE
+.\}

--- a/docs/man/get_double.3
+++ b/docs/man/get_double.3
@@ -1,0 +1,71 @@
+'\" t
+.\"     Title: get_double
+.\"    Author: [see the "AUTHORS" section]
+.\" Generator: Asciidoctor 1.5.5
+.\"      Date: 2017-07-09
+.\"    Manual: CS50 Programmer's Manual
+.\"    Source: CS50
+.\"  Language: English
+.\"
+.TH "GET_DOUBLE" "3" "2017-07-09" "CS50" "CS50 Programmer\(aqs Manual"
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.ss \n[.ss] 0
+.nh
+.ad l
+.de URL
+\\$2 \(laURL: \\$1 \(ra\\$3
+..
+.if \n[.g] .mso www.tmac
+.LINKSTYLE blue R < >
+.SH "NAME"
+get_double \- prompts user for a line of text from stdin and returns the equivalent double
+.SH "SYNOPSIS"
+.sp
+\fB#include <cs50.h>\fP
+.sp
+\fBdouble get_double(string prompt);\fP
+.SH "DESCRIPTION"
+.sp
+Prompts user for a line of text from standard input and returns the equivalent double as precisely as possible; if text does not represent a double or if value would cause underflow or overflow, user is prompted to retry.
+.SH "RETURN VALUE"
+.sp
+Returns the equivalent double of the line read from stdin, as precisely as possible. If line can\(cqt be read, returns \fBDBL_MAX\fP.
+.SH "EXAMPLE"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+// attempt to read double from stdin
+double d = get_double("Enter double: ");
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+// ensure double was read
+if (d != DBL_MAX)
+{
+    printf("You entered: %f\(rsn", d);
+}
+.fi
+.if n \{\
+.RE
+.\}
+.SH "SEE ALSO"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+get_char(3), get_float(3), get_int(3), get_long_long(3),
+get_string(3)
+.fi
+.if n \{\
+.RE
+.\}

--- a/docs/man/get_float.3
+++ b/docs/man/get_float.3
@@ -1,0 +1,71 @@
+'\" t
+.\"     Title: get_float
+.\"    Author: [see the "AUTHORS" section]
+.\" Generator: Asciidoctor 1.5.5
+.\"      Date: 2017-07-09
+.\"    Manual: CS50 Programmer's Manual
+.\"    Source: CS50
+.\"  Language: English
+.\"
+.TH "GET_FLOAT" "3" "2017-07-09" "CS50" "CS50 Programmer\(aqs Manual"
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.ss \n[.ss] 0
+.nh
+.ad l
+.de URL
+\\$2 \(laURL: \\$1 \(ra\\$3
+..
+.if \n[.g] .mso www.tmac
+.LINKSTYLE blue R < >
+.SH "NAME"
+get_float \- prompts user for a line of text from stdin and returns the equivalent float
+.SH "SYNOPSIS"
+.sp
+\fB#include <cs50.h>\fP
+.sp
+\fBfloat get_float(string prompt);\fP
+.SH "DESCRIPTION"
+.sp
+Prompts user for a line of text from standard input and returns the equivalent float as precisely as possible; if text does not represent a float or if value would cause underflow or overflow, user is prompted to retry.
+.SH "RETURN VALUE"
+.sp
+Returns the equivalent float of the line read from stdin, as precisely as possible. If line can\(cqt be read, returns \fBFLT_MAX\fP.
+.SH "EXAMPLE"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+// attempt to read float from stdin
+float f = get_float("Enter float: ");
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+// ensure float was read
+if (f != FLT_MAX)
+{
+    printf("You entered: %f\(rsn", f);
+}
+.fi
+.if n \{\
+.RE
+.\}
+.SH "SEE ALSO"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+get_char(3), get_double(3), get_int(3), get_long_long(3),
+get_string(3)
+.fi
+.if n \{\
+.RE
+.\}

--- a/docs/man/get_int.3
+++ b/docs/man/get_int.3
@@ -1,0 +1,71 @@
+'\" t
+.\"     Title: get_int
+.\"    Author: [see the "AUTHORS" section]
+.\" Generator: Asciidoctor 1.5.5
+.\"      Date: 2017-07-09
+.\"    Manual: CS50 Programmer's Manual
+.\"    Source: CS50
+.\"  Language: English
+.\"
+.TH "GET_INT" "3" "2017-07-09" "CS50" "CS50 Programmer\(aqs Manual"
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.ss \n[.ss] 0
+.nh
+.ad l
+.de URL
+\\$2 \(laURL: \\$1 \(ra\\$3
+..
+.if \n[.g] .mso www.tmac
+.LINKSTYLE blue R < >
+.SH "NAME"
+get_int \- prompts user for a line of text from stdin and returns the equivalent int
+.SH "SYNOPSIS"
+.sp
+\fB#include <cs50.h>\fP
+.sp
+\fBint get_int(string prompt);\fP
+.SH "DESCRIPTION"
+.sp
+Prompts user for a line of text from standard input and returns the equivalent int; if text does not represent a int in [\fBINT_MIN\fP, \fBINT_MAX\fP) or would cause underflow or overflow, user is prompted to retry.
+.SH "RETURN VALUE"
+.sp
+Returns the equivalent int of the line read from stdin in [\fBINT_MIN\fP, \fBINT_MAX\fP). If line can\(cqt be read, returns \fBINT_MAX\fP.
+.SH "EXAMPLE"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+// attempt to read int from stdin
+int i = get_int("Enter int: ");
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+// ensure int was read
+if (i != INT_MAX)
+{
+    printf("You entered: %i\(rsn", i);
+}
+.fi
+.if n \{\
+.RE
+.\}
+.SH "SEE ALSO"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+get_char(3), get_double(3), get_float(3), get_long_long(3),
+get_string(3)
+.fi
+.if n \{\
+.RE
+.\}

--- a/docs/man/get_long_long.3
+++ b/docs/man/get_long_long.3
@@ -1,0 +1,70 @@
+'\" t
+.\"     Title: get_long_long
+.\"    Author: [see the "AUTHORS" section]
+.\" Generator: Asciidoctor 1.5.5
+.\"      Date: 2017-07-09
+.\"    Manual: CS50 Programmer's Manual
+.\"    Source: CS50
+.\"  Language: English
+.\"
+.TH "GET_LONG_LONG" "3" "2017-07-09" "CS50" "CS50 Programmer\(aqs Manual"
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.ss \n[.ss] 0
+.nh
+.ad l
+.de URL
+\\$2 \(laURL: \\$1 \(ra\\$3
+..
+.if \n[.g] .mso www.tmac
+.LINKSTYLE blue R < >
+.SH "NAME"
+get_long_long \- prompts user for a line of text from stdin and returns the equivalent long long
+.SH "SYNOPSIS"
+.sp
+\fB#include <cs50.h>\fP
+.sp
+\fBlong long get_long_long(string prompt);\fP
+.SH "DESCRIPTION"
+.sp
+Prompts user for a line of text from standard input and returns the equivalent long long; if text does not represent a long long in [\fBLLONG_MIN\fP, \fBLLONG_MAX\fP) or would cause underflow or overflow, user is prompted to retry.
+.SH "RETURN VALUE"
+.sp
+Returns the equivalent long long of the line read from stdin in [\fBLLONG_MIN\fP, \fBLLONG_MAX\fP). If line can\(cqt be read, returns \fBLLONG_MAX\fP.
+.SH "EXAMPLE"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+// attempt to read long long from stdin
+long long ll = get_long_long("Enter long long: ");
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+// ensure long long was read
+if (ll != LLONG_MAX)
+{
+    printf("You entered: %lld\(rsn", ll);
+}
+.fi
+.if n \{\
+.RE
+.\}
+.SH "SEE ALSO"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+get_char(3), get_double(3), get_float(3), get_int(3), get_string(3)
+.fi
+.if n \{\
+.RE
+.\}

--- a/docs/man/get_string.3
+++ b/docs/man/get_string.3
@@ -1,0 +1,71 @@
+'\" t
+.\"     Title: get_string
+.\"    Author: [see the "AUTHORS" section]
+.\" Generator: Asciidoctor 1.5.5
+.\"      Date: 2017-07-09
+.\"    Manual: CS50 Programmer's Manual
+.\"    Source: CS50
+.\"  Language: English
+.\"
+.TH "GET_STRING" "3" "2017-07-09" "CS50" "CS50 Programmer\(aqs Manual"
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.ss \n[.ss] 0
+.nh
+.ad l
+.de URL
+\\$2 \(laURL: \\$1 \(ra\\$3
+..
+.if \n[.g] .mso www.tmac
+.LINKSTYLE blue R < >
+.SH "NAME"
+get_string \- prompts user for a line of text from stdin and returns it as a string
+.SH "SYNOPSIS"
+.sp
+\fB#include <cs50.h>\fP
+.sp
+\fBstring get_string(string prompt);\fP
+.SH "DESCRIPTION"
+.sp
+Prompts user for a line of text from standard input and returns it as a string (char *), sans trailing line ending. Supports CR (\(rsr), LF (\(rsn), and CRLF (\(rsr\(rsn) as line endings. Stores string on heap, but library\(cqs destructor frees memory on program\(cqs exit.
+.SH "RETURN VALUE"
+.sp
+Returns the read line as a string. If user inputs only a line ending, returns "", not NULL. Returns NULL upon error or no input whatsoever (i.e., just EOF).
+.SH "EXAMPLE"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+// attempt to read string from stdin
+string s = get_string("Enter string: ");
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+// ensure string was read
+if (s != NULL)
+{
+    printf("You entered: %s\(rsn", s);
+}
+.fi
+.if n \{\
+.RE
+.\}
+.SH "SEE ALSO"
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+get_char(3), get_double(3), get_float(3), get_int(3),
+get_long_long(3)
+.fi
+.if n \{\
+.RE
+.\}


### PR DESCRIPTION
### Why:

- `$ make install` is broken on macOS, even with the recent change discussed in https://github.com/cs50/libcs50/issues/79
- Students using macOS cannot easily use the CS50 library unless they manually setup.
- Current format of dynamic libraries do not match macOS convention (`.so` vs `.dylib`)

### This PR:

- Adds `Makefile.macos`, which specifically builds and installs the CS50 library on macOS.
- Adds pre-built man pages to `docs/man` and `generate_man.sh` to save some headache from depending on `asciidoctor`
- Would allow `libcs50` to be built and installed using [Homebrew](https://brew.sh/), like so:

```
$ brew install libcs50
==> Using the sandbox
==> Downloading https://github.com/americanhanko/libcs50/archive/8.1.3.tar.gz
==> Downloading from https://codeload.github.com/americanhanko/libcs50/tar.gz/8.1.3
######################################################################## 100.0%
==> make -f Makefile.macos build docs
🍺  /usr/local/Cellar/libcs50/8.1.3: 14 files, 33.2KB, built in 2 seconds
```

#### Sources: 
- [Homebrew Formula Cookbook](https://github.com/Homebrew/brew/blob/master/docs/Formula-Cookbook.md)
- [How to open a Hombrew Pull Request](http://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request.html)


### Notes:

- FWIW, I'm currently enrolled and verified for CS50 2017 on edX.
- Eventually, I think there could be a single `Makefile` - would likely just require some OS conditionals (which I experimented with), but this seemed like the best approach for now.