### PR TITLE
Fix missing-field-initializers warning

### DIFF
--- a/src/cs50.h
+++ b/src/cs50.h
@@ -58,6 +58,12 @@ struct prompt
     string prompt;
 };
 
+/** 
+ * Some compilers warn about the trick we use for optional arguments. This
+ * line overrides this warning.
+ */
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+
 /**
  * Prints an error message, formatted like printf, to standard error, prefixing it with
  * file name and line number from which function was called (which a macro provides).


### PR DESCRIPTION
Add pragma to ignore missing field initializers warning. Tested on Clang 4.0.1, GCC 7.0.1, GCC 4.6.4 (released in 2011) and GCC 4.8.4 (released in 2014).