### PR TITLE
Added printf-like argument support to get_*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,11 @@ deb: build docs
 
 .PHONY: hack
 hack:
-	rm -rf build/hack && mkdir -p build/hack
-	cat src/cs50.h > build/hack/cs50.h
-	echo "\n#ifndef _CS50_C\n#define _CS50_C\n" >> build/hack/cs50.h
-	cat src/cs50.c >> build/hack/cs50.h
+	mkdir -p build/hack
+	echo "\n#ifndef _CS50_C\n#define _CS50_C\ntypedef char *string;\n" > build/hack/cs50.h
+	grep -v '^#include "cs50.h"' src/cs50.c >> build/hack/cs50.h
 	echo "\n#endif" >> build/hack/cs50.h
+	cat src/cs50.h >> build/hack/cs50.h
 
 # used by .travis.yml
 .PHONY: version

--- a/src/cs50.c
+++ b/src/cs50.c
@@ -40,15 +40,22 @@
 
 #include <ctype.h>
 #include <errno.h>
+#include <float.h>
 #include <limits.h>
 #include <math.h>
 #include <stdarg.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "cs50.h"
+
+// Some compilers warn about the way we use variadic arguments in these
+// functions. This disable those warnings.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
 
 // temporarily here for backwards compatibility
 #undef get_char
@@ -88,238 +95,6 @@ void eprintf(char const *file, int line, char const *format, ...)
     va_end(ap);
 }
 
-/**
- * Prompts user for a line of text from standard input and returns the
- * equivalent char; if text is not a single char, user is prompted
- * to retry. If line can't be read, returns CHAR_MAX.
- */
-char get_char(char const *format, ...)
-{
-    va_list ap;
-    va_start(ap, format);
-
-    // try to get a char from user
-    while (true)
-    {
-        // get line of text, returning CHAR_MAX on failure
-        string line = get_string(true, format, &ap);
-        if (line == NULL)
-        {
-            va_end(ap);
-            return CHAR_MAX;
-        }
-
-        // return a char if only a char was provided
-        char c, d;
-        if (sscanf(line, "%c%c", &c, &d) == 1)
-        {
-            va_end(ap);
-            return c;
-        }
-
-        // temporarily here for backwards compatibility
-        if (format == NULL)
-        {
-            printf("Retry: ");
-        }
-    }
-}
-char GetChar(void)
-{
-    return get_char(NULL);
-}
-
-/**
- * Prompts user for a line of text from standard input and returns the
- * equivalent double as precisely as possible; if text does not represent
- * a double or if value would cause underflow or overflow, user is
- * prompted to retry. If line can't be read, returns DBL_MAX.
- */
-double get_double(char const *format, ...)
-{
-    va_list ap;
-    va_start(ap, format);
-    // try to get a double from user
-    while (true)
-    {
-        // get line of text, returning DBL_MAX on failure
-        string line = get_string(true, format, &ap);
-        if (line == NULL)
-        {
-            va_end(ap);
-            return DBL_MAX;
-        }
-
-        // return a double if only a double was provided
-        if (strlen(line) > 0 && !isspace((unsigned char) line[0]))
-        {
-            char *tail;
-            errno = 0;
-            double d = strtod(line, &tail);
-            if (errno == 0 && *tail == '\0' && isfinite(d) != 0 && d < DBL_MAX)
-            {
-                // disallow hexadecimal and exponents
-                if (strcspn(line, "XxEePp") == strlen(line))
-                {
-                    va_end(ap);
-                    return d;
-                }
-            }
-        }
-
-        // temporarily here for backwards compatibility
-        if (format == NULL)
-        {
-            printf("Retry: ");
-        }
-    }
-}
-double GetDouble(void)
-{
-    return get_double(NULL);
-}
-
-/**
- * Prompts user for a line of text from standard input and returns the
- * equivalent float as precisely as possible; if text does not represent
- * a float or if value would cause underflow or overflow, user is prompted
- * to retry. If line can't be read, returns FLT_MAX.
- */
-float get_float(char const *format, ...)
-{
-    va_list ap;
-    va_start(ap, format);
-    // try to get a float from user
-    while (true)
-    {
-        // get line of text, returning FLT_MAX on failure
-        string line = get_string(true, format, &ap);
-        {
-            va_end(ap);
-            return FLT_MAX;
-        }
-
-        // return a float if only a float was provided
-        if (strlen(line) > 0 && !isspace((unsigned char) line[0]))
-        {
-            char *tail;
-            errno = 0;
-            float f = strtof(line, &tail);
-            if (errno == 0 && *tail == '\0' && isfinite(f) != 0 && f < FLT_MAX)
-            {
-                // disallow hexadecimal and exponents
-                if (strcspn(line, "XxEePp") == strlen(line))
-                {
-                    va_end(ap);
-                    return f;
-                }
-            }
-        }
-
-        // temporarily here for backwards compatibility
-        if (format == NULL)
-        {
-            printf("Retry: ");
-        }
-    }
-}
-float GetFloat(void)
-{
-    return get_float(NULL);
-}
-
-/**
- * Prompts user for a line of text from standard input and returns the
- * equivalent int; if text does not represent an int in [-2^31, 2^31 - 1)
- * or would cause underflow or overflow, user is prompted to retry. If line
- * can't be read, returns INT_MAX.
- */
-int get_int(char const *format, ...)
-{
-    va_list ap;
-    va_start(ap, format);
-    // try to get an int from user
-    while (true)
-    {
-        // get line of text, returning INT_MAX on failure
-        string line = get_string(true, format, &ap);
-        if (line == NULL)
-        {
-            va_end(ap);
-            return INT_MAX;
-        }
-
-        // return an int if only an int (in range) was provided
-        if (strlen(line) > 0 && !isspace((unsigned char) line[0]))
-        {
-            char *tail;
-            errno = 0;
-            long n = strtol(line, &tail, 10);
-            if (errno == 0 && *tail == '\0' && n >= INT_MIN && n < INT_MAX)
-            {
-                va_end(ap);
-                return n;
-            }
-        }
-
-        // temporarily here for backwards compatibility
-        if (format == NULL)
-        {
-            printf("Retry: ");
-        }
-    }
-}
-int GetInt(void)
-{
-    return get_int(NULL);
-}
-
-/**
- * Prompts user for a line of text from standard input and returns the
- * equivalent long long; if text does not represent a long long in
- * [-2^63, 2^63 - 1) or would cause underflow or overflow, user is
- * prompted to retry. If line can't be read, returns LLONG_MAX.
- */
-long long get_long_long(char const *format, ...)
-{
-    va_list ap;
-    va_start(ap, format);
-
-    // try to get a long long from user
-    while (true)
-    {
-        // get line of text, returning LLONG_MAX on failure
-        string line = get_string(true, format, &ap);
-        if (line == NULL)
-        {
-            va_end(ap);
-            return LLONG_MAX;
-        }
-
-        // return a long long if only a long long (in range) was provided
-        if (strlen(line) > 0 && !isspace((unsigned char) line[0]))
-        {
-            char *tail;
-            errno = 0;
-            long long n = strtoll(line, &tail, 10);
-            if (errno == 0 && *tail == '\0' && n < LLONG_MAX)
-            {
-                va_end(ap);
-                return n;
-            }
-        }
-
-        // temporarily here for backwards compatibility
-        if (format == NULL)
-        {
-            printf("Retry: ");
-        }
-    }
-}
-long long GetLongLong(void)
-{
-    return get_long_long(NULL);
-}
 
 /**
  * Number of strings allocated by get_string.
@@ -339,11 +114,11 @@ static string *strings = NULL;
  * upon error or no input whatsoever (i.e., just EOF). Stores string
  * on heap, but library's destructor frees memory on program's exit.
  */
-string get_string(bool internal, char const *format, ...)
+string get_string(va_list *args, char const *format, ...)
 {
 
     // check whether we have room for another string
-    if (allocations * sizeof(string) == SIZE_MAX)
+    if (allocations * sizeof (string) == SIZE_MAX)
     {
         return NULL;
     }
@@ -365,20 +140,24 @@ string get_string(bool internal, char const *format, ...)
     {
         // initialize variadic argument list
         va_list ap;
-        va_start(ap, format);
 
-        /** If `get_string` is being called by one of the other libary
-         *  functions, its only other argument will be the argument list of
-         *  that function.
+        /** Student code will pass in printf-like arguments as variadic
+         *  parameters. The student-facing get_string macro always sets args to
+         *  NULL. In this case, we initialize the list of variadic parameters
+         *  the standard way with va_start.
          */
-        if (_internal)
+        if (args == NULL)
         {
-            // get argument list
-            va_list *temp = va_arg(ap, va_list *);
-            va_end(ap);
-
+            va_start(ap, format);
+        }
+        /** When functions in this library call get_string they will have
+         *  already stored their variadic parameters in a `va_list` and so they
+         *  just pass that in by pointer.
+         */
+        else
+        {
             // put a copy of argument list in ap so it is not consumed by vprintf
-            va_copy(ap, *temp);
+            va_copy(ap, *args);
         }
         // print prompt
         vprintf(format, ap);
@@ -461,7 +240,7 @@ string get_string(bool internal, char const *format, ...)
     s[size] = '\0';
 
     // resize array so as to append string
-    string *tmp = realloc(strings, sizeof(string) * (allocations + 1));
+    string *tmp = realloc(strings, sizeof (string) * (allocations + 1));
     if (tmp == NULL)
     {
         free(s);
@@ -568,20 +347,243 @@ string GetString(void)
     return s;
 }
 
+
 /**
- * Called automatically before execution enters main.
+ * Prompts user for a line of text from standard input and returns the
+ * equivalent char; if text is not a single char, user is prompted
+ * to retry. If line can't be read, returns CHAR_MAX.
  */
-__attribute__((constructor))
-static void setup(void)
+char get_char(char const *format, ...)
 {
-    // disable buffering for standard output
-    setvbuf(stdout, NULL, _IONBF, 0);
+    va_list ap;
+    va_start(ap, format);
+
+    // try to get a char from user
+    while (true)
+    {
+        // get line of text, returning CHAR_MAX on failure
+        string line = get_string(&ap, format);
+        if (line == NULL)
+        {
+            va_end(ap);
+            return CHAR_MAX;
+        }
+
+        // return a char if only a char was provided
+        char c, d;
+        if (sscanf(line, "%c%c", &c, &d) == 1)
+        {
+            va_end(ap);
+            return c;
+        }
+
+        // temporarily here for backwards compatibility
+        if (format == NULL)
+        {
+            printf("Retry: ");
+        }
+    }
+}
+char GetChar(void)
+{
+    return get_char(NULL);
+}
+
+/**
+ * Prompts user for a line of text from standard input and returns the
+ * equivalent double as precisely as possible; if text does not represent
+ * a double or if value would cause underflow or overflow, user is
+ * prompted to retry. If line can't be read, returns DBL_MAX.
+ */
+double get_double(char const *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    // try to get a double from user
+    while (true)
+    {
+        // get line of text, returning DBL_MAX on failure
+        string line = get_string(&ap, format);
+        if (line == NULL)
+        {
+            va_end(ap);
+            return DBL_MAX;
+        }
+
+        // return a double if only a double was provided
+        if (strlen(line) > 0 && !isspace((unsigned char) line[0]))
+        {
+            char *tail;
+            errno = 0;
+            double d = strtod(line, &tail);
+            if (errno == 0 && *tail == '\0' && isfinite(d) != 0 && d < DBL_MAX)
+            {
+                // disallow hexadecimal and exponents
+                if (strcspn(line, "XxEePp") == strlen(line))
+                {
+                    va_end(ap);
+                    return d;
+                }
+            }
+        }
+
+        // temporarily here for backwards compatibility
+        if (format == NULL)
+        {
+            printf("Retry: ");
+        }
+    }
+}
+double GetDouble(void)
+{
+    return get_double(NULL);
+}
+
+/**
+ * Prompts user for a line of text from standard input and returns the
+ * equivalent float as precisely as possible; if text does not represent
+ * a float or if value would cause underflow or overflow, user is prompted
+ * to retry. If line can't be read, returns FLT_MAX.
+ */
+float get_float(char const *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    // try to get a float from user
+    while (true)
+    {
+        // get line of text, returning FLT_MAX on failure
+        string line = get_string(&ap, format);
+        {
+            va_end(ap);
+            return FLT_MAX;
+        }
+
+        // return a float if only a float was provided
+        if (strlen(line) > 0 && !isspace((unsigned char) line[0]))
+        {
+            char *tail;
+            errno = 0;
+            float f = strtof(line, &tail);
+            if (errno == 0 && *tail == '\0' && isfinite(f) != 0 && f < FLT_MAX)
+            {
+                // disallow hexadecimal and exponents
+                if (strcspn(line, "XxEePp") == strlen(line))
+                {
+                    va_end(ap);
+                    return f;
+                }
+            }
+        }
+
+        // temporarily here for backwards compatibility
+        if (format == NULL)
+        {
+            printf("Retry: ");
+        }
+    }
+}
+float GetFloat(void)
+{
+    return get_float(NULL);
+}
+
+/**
+ * Prompts user for a line of text from standard input and returns the
+ * equivalent int; if text does not represent an int in [-2^31, 2^31 - 1)
+ * or would cause underflow or overflow, user is prompted to retry. If line
+ * can't be read, returns INT_MAX.
+ */
+int get_int(char const *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    // try to get an int from user
+    while (true)
+    {
+        // get line of text, returning INT_MAX on failure
+        string line = get_string(&ap, format);
+        if (line == NULL)
+        {
+            va_end(ap);
+            return INT_MAX;
+        }
+
+        // return an int if only an int (in range) was provided
+        if (strlen(line) > 0 && !isspace((unsigned char) line[0]))
+        {
+            char *tail;
+            errno = 0;
+            long n = strtol(line, &tail, 10);
+            if (errno == 0 && *tail == '\0' && n >= INT_MIN && n < INT_MAX)
+            {
+                va_end(ap);
+                return n;
+            }
+        }
+
+        // temporarily here for backwards compatibility
+        if (format == NULL)
+        {
+            printf("Retry: ");
+        }
+    }
+}
+int GetInt(void)
+{
+    return get_int(NULL);
+}
+
+/**
+ * Prompts user for a line of text from standard input and returns the
+ * equivalent long long; if text does not represent a long long in
+ * [-2^63, 2^63 - 1) or would cause underflow or overflow, user is
+ * prompted to retry. If line can't be read, returns LLONG_MAX.
+ */
+long long get_long_long(char const *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+
+    // try to get a long long from user
+    while (true)
+    {
+        // get line of text, returning LLONG_MAX on failure
+        string line = get_string(&ap, format);
+        if (line == NULL)
+        {
+            va_end(ap);
+            return LLONG_MAX;
+        }
+
+        // return a long long if only a long long (in range) was provided
+        if (strlen(line) > 0 && !isspace((unsigned char) line[0]))
+        {
+            char *tail;
+            errno = 0;
+            long long n = strtoll(line, &tail, 10);
+            if (errno == 0 && *tail == '\0' && n < LLONG_MAX)
+            {
+                va_end(ap);
+                return n;
+            }
+        }
+
+        // temporarily here for backwards compatibility
+        if (format == NULL)
+        {
+            printf("Retry: ");
+        }
+    }
+}
+long long GetLongLong(void)
+{
+    return get_long_long(NULL);
 }
 
 /**
  * Called automatically after execution exits main.
  */
-__attribute__((destructor))
 static void teardown(void)
 {
     // free library's strings
@@ -594,3 +596,41 @@ static void teardown(void)
         free(strings);
     }
 }
+
+/**
+ * Preprocessor magic to make initializers work somewhat portably
+ * Modified from http://stackoverflow.com/questions/1113409/attribute-constructor-equivalent-in-vc
+ */
+#if defined (_MSC_VER) // MSVC
+    #pragma section(".CRT$XCU",read)
+    #define INITIALIZER_(FUNC,PREFIX) \
+        static void FUNC(void); \
+        __declspec(allocate(".CRT$XCU")) void (*FUNC##_)(void) = FUNC; \
+        __pragma(comment(linker,"/include:" PREFIX #FUNC "_")) \
+        static void FUNC(void)
+    #ifdef _WIN64
+        #define INITIALIZER(FUNC) INITIALIZER_(FUNC,"")
+    #else
+        #define INITIALIZER(FUNC) INITIALIZER_(FUNC,"_")
+    #endif
+#elif defined (__GNUC__) // GCC, Clang, MinGW
+    #define INITIALIZER(FUNC) \
+        static void FUNC(void) __attribute__((constructor)); \
+        static void FUNC(void)
+#else
+    #error The CS50 library requires some compiler-specific features, \
+           but we do not recognize this compiler/version. Please file an issue at \
+           github.com/cs50/libcs50
+#endif
+
+/**
+ * Called automatically before execution enters main.
+ */
+INITIALIZER(setup)
+{
+    // disable buffering for standard output
+    setvbuf(stdout, NULL, _IONBF, 0);
+    atexit(teardown);
+}
+
+#pragma GCC diagnostic pop

--- a/src/cs50.c
+++ b/src/cs50.c
@@ -57,7 +57,6 @@
 #undef get_int
 #undef get_long_long
 #undef get_string
-#define null (&(struct prompt) {0})
 
 /**
  * Prints an error message, formatted like printf, to standard error, prefixing it with
@@ -71,7 +70,7 @@
  * https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html.
  */
 #undef eprintf
-void eprintf(const char *file, int line, const char *format, ...)
+void eprintf(char const *file, int line, char const *format, ...)
 {
     // print caller's file name and line number
     fprintf(stderr, "%s:%i: ", file, line);
@@ -94,15 +93,19 @@ void eprintf(const char *file, int line, const char *format, ...)
  * equivalent char; if text is not a single char, user is prompted
  * to retry. If line can't be read, returns CHAR_MAX.
  */
-char get_char(struct prompt *p)
+char get_char(char const *fmt, ...)
 {
+    va_list ap;
+    va_start(ap, fmt);
+
     // try to get a char from user
     while (true)
     {
         // get line of text, returning CHAR_MAX on failure
-        string line = get_string(p);
+        string line = get_string(true, fmt, &ap);
         if (line == NULL)
         {
+            va_end(ap);
             return CHAR_MAX;
         }
 
@@ -110,11 +113,12 @@ char get_char(struct prompt *p)
         char c, d;
         if (sscanf(line, "%c%c", &c, &d) == 1)
         {
+            va_end(ap);
             return c;
         }
 
         // temporarily here for backwards compatibility
-        if (p->prompt == NULL)
+        if (fmt == NULL)
         {
             printf("Retry: ");
         }
@@ -122,7 +126,7 @@ char get_char(struct prompt *p)
 }
 char GetChar(void)
 {
-    return get_char(null);
+    return get_char(NULL);
 }
 
 /**
@@ -131,15 +135,18 @@ char GetChar(void)
  * a double or if value would cause underflow or overflow, user is
  * prompted to retry. If line can't be read, returns DBL_MAX.
  */
-double get_double(struct prompt *p)
+double get_double(char const *fmt, ...)
 {
+    va_list ap;
+    va_start(ap, fmt);
     // try to get a double from user
     while (true)
     {
         // get line of text, returning DBL_MAX on failure
-        string line = get_string(p);
+        string line = get_string(true, fmt, &ap);
         if (line == NULL)
         {
+            va_end(ap);
             return DBL_MAX;
         }
 
@@ -154,13 +161,14 @@ double get_double(struct prompt *p)
                 // disallow hexadecimal and exponents
                 if (strcspn(line, "XxEePp") == strlen(line))
                 {
+                    va_end(ap);
                     return d;
                 }
             }
         }
 
         // temporarily here for backwards compatibility
-        if (p->prompt == NULL)
+        if (fmt == NULL)
         {
             printf("Retry: ");
         }
@@ -168,7 +176,7 @@ double get_double(struct prompt *p)
 }
 double GetDouble(void)
 {
-    return get_double(null);
+    return get_double(NULL);
 }
 
 /**
@@ -177,15 +185,17 @@ double GetDouble(void)
  * a float or if value would cause underflow or overflow, user is prompted
  * to retry. If line can't be read, returns FLT_MAX.
  */
-float get_float(struct prompt *p)
+float get_float(char const *fmt, ...)
 {
+    va_list ap;
+    va_start(ap, fmt);
     // try to get a float from user
     while (true)
     {
         // get line of text, returning FLT_MAX on failure
-        string line = get_string(p);
-        if (line == NULL)
+        string line = get_string(true, fmt, &ap);
         {
+            va_end(ap);
             return FLT_MAX;
         }
 
@@ -200,13 +210,14 @@ float get_float(struct prompt *p)
                 // disallow hexadecimal and exponents
                 if (strcspn(line, "XxEePp") == strlen(line))
                 {
+                    va_end(ap);
                     return f;
                 }
             }
         }
 
         // temporarily here for backwards compatibility
-        if (p->prompt == NULL)
+        if (fmt == NULL)
         {
             printf("Retry: ");
         }
@@ -214,7 +225,7 @@ float get_float(struct prompt *p)
 }
 float GetFloat(void)
 {
-    return get_float(null);
+    return get_float(NULL);
 }
 
 /**
@@ -223,15 +234,18 @@ float GetFloat(void)
  * or would cause underflow or overflow, user is prompted to retry. If line
  * can't be read, returns INT_MAX.
  */
-int get_int(struct prompt *p)
+int get_int(char const *fmt, ...)
 {
+    va_list ap;
+    va_start(ap, fmt);
     // try to get an int from user
     while (true)
     {
         // get line of text, returning INT_MAX on failure
-        string line = get_string(p);
+        string line = get_string(true, fmt, &ap);
         if (line == NULL)
         {
+            va_end(ap);
             return INT_MAX;
         }
 
@@ -243,12 +257,13 @@ int get_int(struct prompt *p)
             long n = strtol(line, &tail, 10);
             if (errno == 0 && *tail == '\0' && n >= INT_MIN && n < INT_MAX)
             {
+                va_end(ap);
                 return n;
             }
         }
 
         // temporarily here for backwards compatibility
-        if (p->prompt == NULL)
+        if (fmt == NULL)
         {
             printf("Retry: ");
         }
@@ -256,7 +271,7 @@ int get_int(struct prompt *p)
 }
 int GetInt(void)
 {
-    return get_int(null);
+    return get_int(NULL);
 }
 
 /**
@@ -265,15 +280,19 @@ int GetInt(void)
  * [-2^63, 2^63 - 1) or would cause underflow or overflow, user is
  * prompted to retry. If line can't be read, returns LLONG_MAX.
  */
-long long get_long_long(struct prompt *p)
+long long get_long_long(char const *fmt, ...)
 {
+    va_list ap;
+    va_start(ap, fmt);
+
     // try to get a long long from user
     while (true)
     {
         // get line of text, returning LLONG_MAX on failure
-        string line = get_string(p);
+        string line = get_string(true, fmt, &ap);
         if (line == NULL)
         {
+            va_end(ap);
             return LLONG_MAX;
         }
 
@@ -285,12 +304,13 @@ long long get_long_long(struct prompt *p)
             long long n = strtoll(line, &tail, 10);
             if (errno == 0 && *tail == '\0' && n < LLONG_MAX)
             {
+                va_end(ap);
                 return n;
             }
         }
 
         // temporarily here for backwards compatibility
-        if (p->prompt == NULL)
+        if (fmt == NULL)
         {
             printf("Retry: ");
         }
@@ -298,7 +318,7 @@ long long get_long_long(struct prompt *p)
 }
 long long GetLongLong(void)
 {
-    return get_long_long(null);
+    return get_long_long(NULL);
 }
 
 /**
@@ -319,8 +339,9 @@ static string *strings = NULL;
  * upon error or no input whatsoever (i.e., just EOF). Stores string
  * on heap, but library's destructor frees memory on program's exit.
  */
-string get_string(struct prompt *p)
+string get_string(bool internal, char const *fmt, ...)
 {
+
     // check whether we have room for another string
     if (allocations * sizeof(string) == SIZE_MAX)
     {
@@ -340,9 +361,17 @@ string get_string(struct prompt *p)
     int c;
 
     // prompt user
-    if (p->prompt != NULL)
+    if (fmt != NULL)
     {
-        printf("%s", p->prompt);
+        va_list ap;
+        va_start(ap, fmt);
+        if (internal) {
+            va_list *temp = va_arg(ap, va_list *);
+            va_end(ap);
+            va_copy(ap, *temp);
+        }
+        vprintf(fmt, ap);
+        va_end(ap);
     }
 
     // iteratively get characters from standard input, checking for CR (Mac OS), LF (Linux), and CRLF (Windows)

--- a/src/cs50.c
+++ b/src/cs50.c
@@ -93,16 +93,16 @@ void eprintf(char const *file, int line, char const *format, ...)
  * equivalent char; if text is not a single char, user is prompted
  * to retry. If line can't be read, returns CHAR_MAX.
  */
-char get_char(char const *fmt, ...)
+char get_char(char const *format, ...)
 {
     va_list ap;
-    va_start(ap, fmt);
+    va_start(ap, format);
 
     // try to get a char from user
     while (true)
     {
         // get line of text, returning CHAR_MAX on failure
-        string line = get_string(true, fmt, &ap);
+        string line = get_string(true, format, &ap);
         if (line == NULL)
         {
             va_end(ap);
@@ -118,7 +118,7 @@ char get_char(char const *fmt, ...)
         }
 
         // temporarily here for backwards compatibility
-        if (fmt == NULL)
+        if (format == NULL)
         {
             printf("Retry: ");
         }
@@ -135,15 +135,15 @@ char GetChar(void)
  * a double or if value would cause underflow or overflow, user is
  * prompted to retry. If line can't be read, returns DBL_MAX.
  */
-double get_double(char const *fmt, ...)
+double get_double(char const *format, ...)
 {
     va_list ap;
-    va_start(ap, fmt);
+    va_start(ap, format);
     // try to get a double from user
     while (true)
     {
         // get line of text, returning DBL_MAX on failure
-        string line = get_string(true, fmt, &ap);
+        string line = get_string(true, format, &ap);
         if (line == NULL)
         {
             va_end(ap);
@@ -168,7 +168,7 @@ double get_double(char const *fmt, ...)
         }
 
         // temporarily here for backwards compatibility
-        if (fmt == NULL)
+        if (format == NULL)
         {
             printf("Retry: ");
         }
@@ -185,15 +185,15 @@ double GetDouble(void)
  * a float or if value would cause underflow or overflow, user is prompted
  * to retry. If line can't be read, returns FLT_MAX.
  */
-float get_float(char const *fmt, ...)
+float get_float(char const *format, ...)
 {
     va_list ap;
-    va_start(ap, fmt);
+    va_start(ap, format);
     // try to get a float from user
     while (true)
     {
         // get line of text, returning FLT_MAX on failure
-        string line = get_string(true, fmt, &ap);
+        string line = get_string(true, format, &ap);
         {
             va_end(ap);
             return FLT_MAX;
@@ -217,7 +217,7 @@ float get_float(char const *fmt, ...)
         }
 
         // temporarily here for backwards compatibility
-        if (fmt == NULL)
+        if (format == NULL)
         {
             printf("Retry: ");
         }
@@ -234,15 +234,15 @@ float GetFloat(void)
  * or would cause underflow or overflow, user is prompted to retry. If line
  * can't be read, returns INT_MAX.
  */
-int get_int(char const *fmt, ...)
+int get_int(char const *format, ...)
 {
     va_list ap;
-    va_start(ap, fmt);
+    va_start(ap, format);
     // try to get an int from user
     while (true)
     {
         // get line of text, returning INT_MAX on failure
-        string line = get_string(true, fmt, &ap);
+        string line = get_string(true, format, &ap);
         if (line == NULL)
         {
             va_end(ap);
@@ -263,7 +263,7 @@ int get_int(char const *fmt, ...)
         }
 
         // temporarily here for backwards compatibility
-        if (fmt == NULL)
+        if (format == NULL)
         {
             printf("Retry: ");
         }
@@ -280,16 +280,16 @@ int GetInt(void)
  * [-2^63, 2^63 - 1) or would cause underflow or overflow, user is
  * prompted to retry. If line can't be read, returns LLONG_MAX.
  */
-long long get_long_long(char const *fmt, ...)
+long long get_long_long(char const *format, ...)
 {
     va_list ap;
-    va_start(ap, fmt);
+    va_start(ap, format);
 
     // try to get a long long from user
     while (true)
     {
         // get line of text, returning LLONG_MAX on failure
-        string line = get_string(true, fmt, &ap);
+        string line = get_string(true, format, &ap);
         if (line == NULL)
         {
             va_end(ap);
@@ -310,7 +310,7 @@ long long get_long_long(char const *fmt, ...)
         }
 
         // temporarily here for backwards compatibility
-        if (fmt == NULL)
+        if (format == NULL)
         {
             printf("Retry: ");
         }
@@ -339,7 +339,7 @@ static string *strings = NULL;
  * upon error or no input whatsoever (i.e., just EOF). Stores string
  * on heap, but library's destructor frees memory on program's exit.
  */
-string get_string(bool internal, char const *fmt, ...)
+string get_string(bool internal, char const *format, ...)
 {
 
     // check whether we have room for another string
@@ -361,16 +361,28 @@ string get_string(bool internal, char const *fmt, ...)
     int c;
 
     // prompt user
-    if (fmt != NULL)
+    if (format != NULL)
     {
+        // initialize variadic argument list
         va_list ap;
-        va_start(ap, fmt);
-        if (internal) {
+        va_start(ap, format);
+
+        /** If `get_string` is being called by one of the other libary
+         *  functions, its only other argument will be the argument list of
+         *  that function.
+         */
+        if (_internal)
+        {
+            // get argument list
             va_list *temp = va_arg(ap, va_list *);
             va_end(ap);
+
+            // put a copy of argument list in ap so it is not consumed by vprintf
             va_copy(ap, *temp);
         }
-        vprintf(fmt, ap);
+        // print prompt
+        vprintf(format, ap);
+        // cleanup argument list
         va_end(ap);
     }
 

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -51,6 +51,7 @@ typedef char *string;
 
 /**
  * Temporarily used to make arguments to get_* (but not Get*) optional.
+ * Inspired by https://gustedt.wordpress.com/2010/06/08/detect-empty-macro-arguments/
  */
 
 #define CONCAT(a, b) a ## b 
@@ -67,15 +68,35 @@ typedef char *string;
 #define IF_1_ELSE(...)
 #define IF_0_ELSE(...) __VA_ARGS__
 
-#define ARG(_0, _1, _2, _3, _4, _5, _6, _7, _8,             \
-            _9, _10, _11, _12, _13, _14, _15, _16,          \
-            _17, _18, _19, _20, _21, _22, _23, _24,         \
-            _25, _26, _27, _28, _29, _30, _31, ...) _31
+#define ARG(_0, _1, _2, _3, _4, _5, _6, _7,                 \
+            _8, _9, _10, _11, _12, _13, _14, _15,           \
+            _16, _17, _18, _19, _20, _21, _22, _23,         \
+            _24, _25, _26, _27, _28, _29, _30, _31,         \
+            _32, _33, _34, _35, _36, _37, _38, _39,         \
+            _40, _41, _42, _43, _44, _45, _46, _47,         \
+            _48, _49, _50, _51, _52, _53, _54, _55,         \
+            _56, _57, _58, _59, _60, _61, _62, _63,         \
+            _64, _65, _66, _67, _68, _69, _70, _71,         \
+            _72, _73, _74, _75, _76, _77, _78, _79,         \
+            _80, _81, _82, _83, _84, _85, _86, _87,         \
+            _88, _89, _90, _91, _92, _93, _94, _95,         \
+            _96, _97, _98, _99, _100, _101, _102, _103,     \
+            _104, _105, _106, _107, _108, _109, _110, _111, \
+            _112, _113, _114, _115, _116, _117, _118, _119, \
+            _120, _121, _122,_123, _124, _125, ...) _125
 
-#define HAS_COMMA(...)  ARG(__VA_ARGS__, 1, 1, 1, 1,        \
-                            1, 1, 1, 1, 1, 1, 1, 1, 1,      \
-                            1, 1, 1, 1, 1, 1, 1, 1, 1,      \
-                            1, 1, 1, 1, 1, 1, 1, 1, 0)
+
+#define HAS_COMMA(...) ARG(__VA_ARGS__, 1, 1, 1, 1, 1, 1, 1, 1, 1,  \
+                           1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,   \
+                           1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,   \
+                           1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,   \
+                           1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,   \
+                           1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,   \
+                           1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,   \
+                           1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,   \
+                           1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,   \
+                           1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0)
+                     
 #define TRIGGER(...) ,
  
 #define IS_PAREN(...)       HAS_COMMA(TRIGGER __VA_ARGS__)
@@ -109,14 +130,14 @@ void eprintf(const char *file, int line, const char *format, ...) __attribute__(
  * Macro that allows function of the same name to be called without specifying caller's
  * file name or line number explicitly.
  */
-#define eprintf(format, ...) eprintf(__FILE__, __LINE__, format, ##__VA_ARGS__)
+#define eprintf(...) eprintf(__FILE__, __LINE__, __VA_ARGS__)
 
 /**
  * Prompts user for a line of text from standard input and returns the
  * equivalent char; if text is not a single char, user is prompted
  * to retry. If line can't be read, returns CHAR_MAX.
  */
-char get_char(char const *fmt, ...) __attribute__((format(printf, 1, 2)));
+char get_char(char const *format, ...) __attribute__((format(printf, 1, 2)));
 char GetChar(void) __attribute__((deprecated));
 #define get_char(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(get_char(NULL))(get_char(__VA_ARGS__))
 
@@ -126,7 +147,7 @@ char GetChar(void) __attribute__((deprecated));
  * a double or if value would cause underflow or overflow, user is
  * prompted to retry. If line can't be read, returns DBL_MAX.
  */
-double get_double(char const *fmt, ...) __attribute__((format(printf, 1, 2)));
+double get_double(char const *format, ...) __attribute__((format(printf, 1, 2)));
 double GetDouble(void) __attribute__((deprecated));
 #define get_double(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(get_double(NULL))(get_double(__VA_ARGS__))
 
@@ -136,7 +157,7 @@ double GetDouble(void) __attribute__((deprecated));
  * a float or if value would cause underflow or overflow, user is prompted
  * to retry. If line can't be read, returns FLT_MAX.
  */
-float get_float(char const *fmt, ...) __attribute__((format(printf, 1, 2)));
+float get_float(char const *format, ...) __attribute__((format(printf, 1, 2)));
 float GetFloat(void) __attribute__((deprecated));
 #define get_float(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(get_float(NULL))(get_float(__VA_ARGS__))
 
@@ -146,7 +167,7 @@ float GetFloat(void) __attribute__((deprecated));
  * or would cause underflow or overflow, user is prompted to retry. If line
  * can't be read, returns INT_MAX.
  */
-int get_int(char const *fmt, ...) __attribute__((format(printf, 1, 2)));
+int get_int(char const *format, ...) __attribute__((format(printf, 1, 2)));
 int GetInt(void) __attribute__((deprecated));
 #define get_int(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(get_int(NULL))(get_int(__VA_ARGS__))
 
@@ -156,7 +177,7 @@ int GetInt(void) __attribute__((deprecated));
  * [-2^63, 2^63 - 1) or would cause underflow or overflow, user is
  * prompted to retry. If line can't be read, returns LLONG_MAX.
  */
-long long get_long_long(char const *fmt, ...) __attribute__((format(printf, 1, 2)));
+long long get_long_long(char const *format, ...) __attribute__((format(printf, 1, 2)));
 long long GetLongLong(void) __attribute__((deprecated));
 #define get_long_long(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(get_long_long(NULL))(get_long_long(__VA_ARGS__))
 
@@ -168,8 +189,7 @@ long long GetLongLong(void) __attribute__((deprecated));
  * upon error or no input whatsoever (i.e., just EOF). Stores string
  * on heap, but library's destructor frees memory on program's exit.
  */
-
-string get_string(bool _internal, char const *fmt, ...) __attribute__((format(printf, 2, 3)));
+string get_string(bool _internal, char const *format, ...) __attribute__((format(printf, 2, 3)));
 string GetString(void) __attribute__((deprecated));
 #define get_string(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(get_string(false, NULL))(get_string(false, __VA_ARGS__))
 

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -41,6 +41,7 @@
 
 #include <float.h>
 #include <limits.h>
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdlib.h>
 
@@ -112,6 +113,13 @@ typedef char *string;
 #define ALL_FALSE(_0, _1, _2, _3) HAS_COMMA(CONCAT5(FALSE_SENTINEL_, _0, _1, _2, _3))
 #define FALSE_SENTINEL_0000 ,
 
+#define WARN_MSG "GCC warning \"As of Jan 1, 2018 all 'get_' functions require at least one argument (a prompt). Please see reference.cs50.net/cs50 for more information.\""
+#define WARN(func)  do { _Pragma(WARN_MSG); func; } while (0)
+
+// TODO: Remove these two lines once no-argument function calls are deprecated
+#undef WARN
+#define WARN(func) func
+
 
 /**
  * Prints an error message, formatted like printf, to standard error, prefixing it with
@@ -139,7 +147,7 @@ void eprintf(const char *file, int line, const char *format, ...) __attribute__(
  */
 char get_char(char const *format, ...) __attribute__((format(printf, 1, 2)));
 char GetChar(void) __attribute__((deprecated));
-#define get_char(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(get_char(NULL))(get_char(__VA_ARGS__))
+#define get_char(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_char(NULL)))(get_char(__VA_ARGS__))
 
 /**
  * Prompts user for a line of text from standard input and returns the
@@ -149,7 +157,7 @@ char GetChar(void) __attribute__((deprecated));
  */
 double get_double(char const *format, ...) __attribute__((format(printf, 1, 2)));
 double GetDouble(void) __attribute__((deprecated));
-#define get_double(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(get_double(NULL))(get_double(__VA_ARGS__))
+#define get_double(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_double(NULL)))(get_double(__VA_ARGS__))
 
 /**
  * Prompts user for a line of text from standard input and returns the
@@ -159,7 +167,7 @@ double GetDouble(void) __attribute__((deprecated));
  */
 float get_float(char const *format, ...) __attribute__((format(printf, 1, 2)));
 float GetFloat(void) __attribute__((deprecated));
-#define get_float(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(get_float(NULL))(get_float(__VA_ARGS__))
+#define get_float(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_float(NULL)))(get_float(__VA_ARGS__))
 
 /**
  * Prompts user for a line of text from standard input and returns the
@@ -169,7 +177,7 @@ float GetFloat(void) __attribute__((deprecated));
  */
 int get_int(char const *format, ...) __attribute__((format(printf, 1, 2)));
 int GetInt(void) __attribute__((deprecated));
-#define get_int(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(get_int(NULL))(get_int(__VA_ARGS__))
+#define get_int(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_int(NULL)))(get_int(__VA_ARGS__))
 
 /**
  * Prompts user for a line of text from standard input and returns the
@@ -179,7 +187,7 @@ int GetInt(void) __attribute__((deprecated));
  */
 long long get_long_long(char const *format, ...) __attribute__((format(printf, 1, 2)));
 long long GetLongLong(void) __attribute__((deprecated));
-#define get_long_long(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(get_long_long(NULL))(get_long_long(__VA_ARGS__))
+#define get_long_long(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_long_long(NULL)))(get_long_long(__VA_ARGS__))
 
 /**
  * Prompts user for a line of text from standard input and returns
@@ -189,8 +197,8 @@ long long GetLongLong(void) __attribute__((deprecated));
  * upon error or no input whatsoever (i.e., just EOF). Stores string
  * on heap, but library's destructor frees memory on program's exit.
  */
-string get_string(bool _internal, char const *format, ...) __attribute__((format(printf, 2, 3)));
+string get_string(va_list *args, char const *format, ...) __attribute__((format(printf, 2, 3)));
 string GetString(void) __attribute__((deprecated));
-#define get_string(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(get_string(false, NULL))(get_string(false, __VA_ARGS__))
+#define get_string(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_string(NULL, NULL)))(get_string(NULL, __VA_ARGS__))
 
 #endif


### PR DESCRIPTION
Number of arguments for `get_*` is currently capped at 31, but we could increase arbitrarily.

Resolves #91 