### PR TITLE
Allow library to be compiled with -pedantic

### DIFF
--- a/src/cs50.h
+++ b/src/cs50.h
@@ -120,6 +120,13 @@ typedef char *string;
 #undef WARN
 #define WARN(func) func
 
+/** 
+ * If compiler isn't GCC or Clang it may not support __extension__, 
+ * better to suppress this error and hope for the best 
+ */
+#ifndef __GNUC__
+    #define __extension__
+#endif
 
 /**
  * Prints an error message, formatted like printf, to standard error, prefixing it with
@@ -147,7 +154,7 @@ void eprintf(const char *file, int line, const char *format, ...) __attribute__(
  */
 char get_char(char const *format, ...) __attribute__((format(printf, 1, 2)));
 char GetChar(void) __attribute__((deprecated));
-#define get_char(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_char(NULL)))(get_char(__VA_ARGS__))
+#define get_char(...) __extension__ IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_char(NULL)))(get_char(__VA_ARGS__))
 
 /**
  * Prompts user for a line of text from standard input and returns the
@@ -157,7 +164,7 @@ char GetChar(void) __attribute__((deprecated));
  */
 double get_double(char const *format, ...) __attribute__((format(printf, 1, 2)));
 double GetDouble(void) __attribute__((deprecated));
-#define get_double(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_double(NULL)))(get_double(__VA_ARGS__))
+#define get_double(...) __extension__ IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_double(NULL)))(get_double(__VA_ARGS__))
 
 /**
  * Prompts user for a line of text from standard input and returns the
@@ -167,7 +174,7 @@ double GetDouble(void) __attribute__((deprecated));
  */
 float get_float(char const *format, ...) __attribute__((format(printf, 1, 2)));
 float GetFloat(void) __attribute__((deprecated));
-#define get_float(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_float(NULL)))(get_float(__VA_ARGS__))
+#define get_float(...) __extension__ IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_float(NULL)))(get_float(__VA_ARGS__))
 
 /**
  * Prompts user for a line of text from standard input and returns the
@@ -177,7 +184,7 @@ float GetFloat(void) __attribute__((deprecated));
  */
 int get_int(char const *format, ...) __attribute__((format(printf, 1, 2)));
 int GetInt(void) __attribute__((deprecated));
-#define get_int(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_int(NULL)))(get_int(__VA_ARGS__))
+#define get_int(...) __extension__ IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_int(NULL)))(get_int(__VA_ARGS__))
 
 /**
  * Prompts user for a line of text from standard input and returns the
@@ -187,7 +194,7 @@ int GetInt(void) __attribute__((deprecated));
  */
 long long get_long_long(char const *format, ...) __attribute__((format(printf, 1, 2)));
 long long GetLongLong(void) __attribute__((deprecated));
-#define get_long_long(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_long_long(NULL)))(get_long_long(__VA_ARGS__))
+#define get_long_long(...) __extension__ IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_long_long(NULL)))(get_long_long(__VA_ARGS__))
 
 /**
  * Prompts user for a line of text from standard input and returns
@@ -199,6 +206,6 @@ long long GetLongLong(void) __attribute__((deprecated));
  */
 string get_string(va_list *args, char const *format, ...) __attribute__((format(printf, 2, 3)));
 string GetString(void) __attribute__((deprecated));
-#define get_string(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_string(NULL, NULL)))(get_string(NULL, __VA_ARGS__))
+#define get_string(...) __extension__ IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_string(NULL, NULL)))(get_string(NULL, __VA_ARGS__))
 
 #endif


### PR DESCRIPTION
Currently, compiling with `-pedantic` causes a lot of confusing warnings. This PR uses clang and GCC's `__extension__` to suppress these warnings. This isn't urgent by any means; AFAIK, none of our makefiles compile with `-pedantic` but we may as well suppress these just in case.