### PR TITLE
Add get_long

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 8.0.7
+VERSION := 8.1.0
 MAJOR_VERSION := $(shell echo $(VERSION) | head -c 1)
 
 # installation directory (/usr/local by default)

--- a/README.md
+++ b/README.md
@@ -56,13 +56,15 @@ Link with `-lcs50`.
     #include <cs50.h>
 
     ...
+    char c = get_char("Prompt: ");
+    double d = get_double("Prompt: ");
+    float f = get_float("Prompt: ");
+    int i = get_int("Prompt: ");
+    long l = get_long("Prompt: ");
+    string s = get_string("Prompt: ");
 
-    char c = get_char();
-    double d = get_double();
-    float f = get_float();
-    int i = get_int();
-    long long ll = get_long_long();
-    string s = get_string();
+    // deprecated as of fall 2017
+    long long ll = get_long_long("Prompt: ");
 
 ## Documentation
 

--- a/debian/libcs50.manpages
+++ b/debian/libcs50.manpages
@@ -3,5 +3,6 @@ debian/docs/get_char.3
 debian/docs/get_double.3
 debian/docs/get_float.3
 debian/docs/get_int.3
+debian/docs/get_long.3
 debian/docs/get_long_long.3
 debian/docs/get_string.3

--- a/docs/get_char.adoc
+++ b/docs/get_char.adoc
@@ -50,5 +50,5 @@ int main(void)
 
 == SEE ALSO
 
-    get_double(3), get_float(3), get_int(3), get_long_long(3),
+    get_double(3), get_float(3), get_int(3), get_long(3),
     get_string(3), printf(3)

--- a/docs/get_double.adoc
+++ b/docs/get_double.adoc
@@ -54,5 +54,5 @@ double divide_doubles(void)
 
 == SEE ALSO
 
-    get_char(3), get_float(3), get_int(3), get_long_long(3),
+    get_char(3), get_float(3), get_int(3), get_long(3),
     get_string(3), printf(3)

--- a/docs/get_float.adoc
+++ b/docs/get_float.adoc
@@ -53,5 +53,5 @@ float multiply_floats(void)
 
 == SEE ALSO
 
-    get_char(3), get_double(3), get_int(3), get_long_long(3),
+    get_char(3), get_double(3), get_int(3), get_long(3),
     get_string(3)

--- a/docs/get_int.adoc
+++ b/docs/get_int.adoc
@@ -53,5 +53,5 @@ int add_ints(void)
 
 == SEE ALSO
 
-    get_char(3), get_double(3), get_float(3), get_long_long(3),
+    get_char(3), get_double(3), get_float(3), get_long(3),
     get_string(3), printf(3)

--- a/docs/get_long.adoc
+++ b/docs/get_long.adoc
@@ -1,0 +1,57 @@
+= get_long(3)
+:manmanual: CS50 Programmer's Manual
+:mansource: CS50
+:man-linkstyle: pass:[blue R < >]
+
+== NAME
+
+get_long - prompts user for a line of text from stdin and returns the equivalent long
+
+== SYNOPSIS
+
+*#include <cs50.h>*
+
+*long get_long(const char *format, ...);*
+
+== DESCRIPTION
+
+Prompts user for a line of text from standard input and returns the equivalent long; if the text does not represent a long or would cause overflow, user is reprompted.
+
+The prompt is formatted like *printf(3)*.
+
+== RETURN VALUE
+
+Returns the long equivalent to the line read from stdin in [*LONG_MIN*, *LONG_MAX*). If line can't be read, returns *LONG_MAX*.
+
+== EXAMPLE
+
+....
+/**
+ * Returns the difference of two longs read from stdin, or LONG_MAX if there was an error.
+ */
+long subtract_longs(void)
+{
+    // read long from stdin
+    long i = get_long("Enter a long: ");
+
+    // make sure we read one successfully
+    if (i == LONG_MAX)
+    {
+        return LONG_MAX;
+    }
+
+    long j = get_long("What do you want to subtract from %ld? ", i);
+
+    if (j == LONG_MAX)
+    {
+        return LONG_MAX;
+    }
+
+    return i - j;
+}
+....
+
+== SEE ALSO
+
+    get_char(3), get_double(3), get_float(3), get_int(3), get_string(3),
+    printf(3)

--- a/docs/get_long_long.adoc
+++ b/docs/get_long_long.adoc
@@ -19,6 +19,8 @@ Prompts user for a line of text from standard input and returns the equivalent l
 
 The prompt is formatted like *printf(3)*.
 
+This function will be deprecated in favor of *get_long(3)*.
+
 == RETURN VALUE
 
 Returns the long long equivalent to the line read from stdin in [*LLONG_MIN*, *LLONG_MAX*). If line can't be read, returns *LLONG_MAX*.
@@ -53,5 +55,5 @@ long long subtract_long_longs(void)
 
 == SEE ALSO
 
-    get_char(3), get_double(3), get_float(3), get_int(3), get_string(3),
-    printf(3)
+    get_char(3), get_double(3), get_float(3), get_int(3), get_long(3),
+    get_string(3), printf(3)

--- a/docs/get_string.adoc
+++ b/docs/get_string.adoc
@@ -50,4 +50,4 @@ int main(void)
 == SEE ALSO
 
     get_char(3), get_double(3), get_float(3), get_int(3),
-    get_long_long(3), printf(3)
+    get_long(3), printf(3)

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -191,10 +191,21 @@ int GetInt(void) __attribute__((deprecated));
  * equivalent long long; if text does not represent a long long in
  * [-2^63, 2^63 - 1) or would cause underflow or overflow, user is
  * prompted to retry. If line can't be read, returns LLONG_MAX.
+ *
+ * This will be deprecated in favor of get_long.
  */
 long long get_long_long(const string format, ...) __attribute__((format(printf, 1, 2)));
 long long GetLongLong(void) __attribute__((deprecated));
 #define get_long_long(...) __extension__ IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_long_long(NULL)))(get_long_long(__VA_ARGS__))
+
+/**
+ * Prompts user for a line of text from standard input and returns the
+ * equivalent long; if text does not represent a long in
+ * [-2^63, 2^63 - 1) or would cause underflow or overflow, user is
+ * prompted to retry. If line can't be read, returns LONG_MAX.
+ */
+long get_long(const string format, ...) __attribute__((format(printf, 1, 2)));
+#define get_long(...) IF_ELSE(ISEMPTY(__VA_ARGS__))(WARN(get_long(NULL)))(get_long(__VA_ARGS__))
 
 /**
  * Prompts user for a line of text from standard input and returns


### PR DESCRIPTION
Per Slack discussion.

`long long` and `long` are the same size in 64-bit, so there's no reason to use the former.