### PR TITLE
Add full version to soname

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,13 @@ ifeq ($(OS),Linux)
 	LIB_BASE := libcs50.so
 	LIB_MAJOR := libcs50.so.$(MAJOR_VERSION)
 	LIB_VERSION := libcs50.so.$(VERSION)
-	LINKER_FLAGS := -Wl,-soname,$(LIB_MAJOR)
+	LINKER_FLAGS := -Wl,-soname,$(LIB_VERSION)
 # Mac
 else ifeq ($(OS),Darwin)
 	LIB_BASE := libcs50.dylib
 	LIB_MAJOR := libcs50-$(MAJOR_VERSION).dylib
 	LIB_VERSION := libcs50-$(VERSION).dylib
-	LINKER_FLAGS := -Wl,-install_name,$(LIB_MAJOR)
+	LINKER_FLAGS := -Wl,-install_name,$(LIB_VERSION)
 endif
 
 LIBS := $(addprefix build/lib/, $(LIB_BASE) $(LIB_MAJOR) $(LIB_VERSION))


### PR DESCRIPTION
@kzidane any reason not to do this? It makes it much easier to tell which version, specifically, of the library the executable was compiled with.

Before the change:
```
$ ldd ./program
        linux-vdso.so.1 (0x00007ffe0108d000)               
        libcs50.so.8 => /usr/lib/libcs50.so.8 (0x00007f08afd52000)                                            
        libc.so.6 => /usr/lib/libc.so.6 (0x00007f08af9ac000)                                                          
        /lib64/ld-linux-x86-64.so.2 (0x00007f08aff56000)   

```
After change
```
$ ldd ./program
        linux-vdso.so.1 (0x00007ffe0108d000)               
        libcs50.so.8.1.0 => /usr/lib/libcs50.so.8.1.0 (0x00007f08afd52000)                                            
        libc.so.6 => /usr/lib/libc.so.6 (0x00007f08af9ac000)                                                          
        /lib64/ld-linux-x86-64.so.2 (0x00007f08aff56000)
```

It's more honest anyway since `libcs50.so.8` is a symlink to the most recent version anyway, no?