### PR TITLE
Fix make hack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,10 @@ deb: $(LIBS) $(MANS)
 .PHONY: hack
 hack:
 	mkdir -p build/hack
-	echo "\n#ifndef _CS50_C\n#define _CS50_C\ntypedef char *string;\n" > build/hack/cs50.h
+	cat src/cs50.h > build/hack/cs50.h
+	printf "\n#ifndef _CS50_C\n#define _CS50_C\n" >> build/hack/cs50.h
 	grep -v '^#include "cs50.h"' src/cs50.c >> build/hack/cs50.h
-	echo "\n#endif" >> build/hack/cs50.h
-	cat src/cs50.h >> build/hack/cs50.h
+	printf "\n#endif\n" >> build/hack/cs50.h
 
 # used by .travis.yml
 .PHONY: version


### PR DESCRIPTION
* Use printf command instead echo. Escape sequences (including \n) are
  not recognized by echo by default and 'echo -e' is not portable.

* Include header file first and then cs50.c to fix build errors like:
```
build/hack/cs50.h:834:84: error: attribute declaration must precede definition
      [-Werror,-Wignored-attributes]
void eprintf(const string file, int line, const string format, ...) __attribute__((format(printf, 3, 4)));
```