### PR TITLE
Adding related project

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ See `man get_*` and `man eprintf` after installation, or [CS50 Reference](https:
 
 *   Add tests.
 
+## Related
+
+- [`abranhe/cs50`](https://github.com/abranhe/cs50): The CS50 Library for C ready to use with [clib](https://github.com/clibs/clib).
+
 ## Contributors
 
 *   [Chad Sharp](https://github.com/crossroads1112)


### PR DESCRIPTION
[clib](https://github.com/clibs/clib) is a popular packge manager for the C community. Being able to add packges easier on you projects is amazing so I decided to create a package to be able to add the CS50 library easy on a new projects, just:

```
$ clib install abranhe/cs50
```

and then you can use easily the CS50 library and as well add other dependencies from `clib` that you could need on your project.

```c
#include <stdio.h>
#include "cs50.h"

int main()
{
	string s = get_string();
	printf("hello, %s\n", s);
	return 0;
}
```