### PR TITLE
removed stdlib.h as unnecessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 9.1.0
+VERSION := 10.0.0
 MAJOR_VERSION := $(shell echo $(VERSION) | head -c 1)
 
 # installation directory (/usr/local by default)

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -43,7 +43,6 @@
 #include <limits.h>
 #include <stdarg.h>
 #include <stdbool.h>
-#include <stdlib.h>
 
 /**
  * Our own type for bytes.

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -43,11 +43,7 @@
 #include <limits.h>
 #include <stdarg.h>
 #include <stdbool.h>
-
-/**
- * Our own type for bytes.
- */
-typedef unsigned char byte;
+#include <stddef.h>
 
 /**
  * Our own type for (pointers to) strings.


### PR DESCRIPTION
Previously, `stdlib.h` was included so that students could use `free`, but library now garbage-collects itself.