### PR TITLE
Fix race condition in Make builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ $(LIBS): $(SRC) $(INCLUDE) Makefile
 	install -m 644 $(INCLUDE) build/include
 	mv $(LIB_VERSION) $(LIB_BASE) $(LIB_STATIC) build/lib
 
+build/lib/$(LIB_BASE): build/lib/$(LIB_MAJOR)
+
+build/lib/$(LIB_MAJOR): build/lib/$(LIB_VERSION)
+
 .PHONY: install
 install: all
 	mkdir -p $(addprefix $(DESTDIR)/, src lib include $(MANDIR))


### PR DESCRIPTION
Hello

This pull request fixes a race condition found in the `Makefile` of the project
Specifically the `$(LIBS)` rule generates multiple libraries, and there can be can be a problematic situation when this rule is run concurrently.

This is the error I get when run `make -j 4`

```
rm -rf build
cc -Wall -Wextra -Werror -pedantic -std=c11 -fPIC -shared -Wl,-soname,libcs50.so.10 -o libcs50.so.10.1.0 src/cs50.c
cc -Wall -Wextra -Werror -pedantic -std=c11 -fPIC -shared -Wl,-soname,libcs50.so.10 -o libcs50.so.10.1.0 src/cs50.c
cc -Wall -Wextra -Werror -pedantic -std=c11 -fPIC -shared -Wl,-soname,libcs50.so.10 -o libcs50.so.10.1.0 src/cs50.c
cc -Wall -Wextra -Werror -pedantic -std=c11 -c -o libcs50.o src/cs50.c
cc -Wall -Wextra -Werror -pedantic -std=c11 -c -o libcs50.o src/cs50.c
cc -Wall -Wextra -Werror -pedantic -std=c11 -c -o libcs50.o src/cs50.c
ar rcs libcs50.a libcs50.o
chmod 644 libcs50.a
rm -f libcs50.o
ln -sf libcs50.so.10.1.0 libcs50.so
mkdir -p build/include build/lib build/src
install -m 644 src/cs50.c build/src
install -m 644 src/cs50.h build/include
mv libcs50.so.10.1.0 libcs50.so libcs50.a build/lib
ar rcs libcs50.a libcs50.o
chmod 644 libcs50.a
rm -f libcs50.o
ln -sf libcs50.so.10.1.0 libcs50.so
mkdir -p build/include build/lib build/src
install -m 644 src/cs50.c build/src
ar rcs libcs50.a libcs50.o
install -m 644 src/cs50.h build/include
ar: libcs50.o: No such file or directory
Makefile:39: recipe for target 'build/lib/libcs50.so.10.1.0' failed
make: *** [build/lib/libcs50.so.10.1.0] Error 1
make: *** Waiting for unfinished jobs....
mv libcs50.so.10.1.0 libcs50.so libcs50.a build/lib
mv: cannot stat 'libcs50.so.10.1.0': No such file or directory
Makefile:39: recipe for target 'build/lib/libcs50.so.10' failed
make: *** [build/lib/libcs50.so.10] Error 1
```

This fix is proposed by the official documentation of Make.
For more details see [here](https://www.gnu.org/software/automake/manual/html_node/Multiple-Outputs.html)