### PR TITLE
Fix install on mac with custom DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SRC := src/cs50.c
 INCLUDE := src/cs50.h
 MANS := $(wildcard docs/*.3.gz)
 
-CFLAGS=-Wall -Wextra -Werror -pedantic -std=c11
+CFLAGS=-Wall -Wextra -Werror -pedantic -std=c11 -O3
 BASENAME=libcs50
 LIB_STATIC=$(BASENAME).a
 LIB_OBJ=$(BASENAME).o

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ else ifeq ($(OS),Darwin)
 	LIB_BASE := $(BASENAME).dylib
 	LIB_MAJOR := $(BASENAME)-$(MAJOR_VERSION).dylib
 	LIB_VERSION := $(BASENAME)-$(VERSION).dylib
-	LINKER_FLAGS := -Wl,-install_name,$(LIB_VERSION)
+	LINKER_FLAGS := -Wl,-install_name,$(DESTDIR)/lib/$(LIB_VERSION)
 endif
 
 LIBS := $(addprefix build/lib/, $(LIB_BASE) $(LIB_MAJOR) $(LIB_VERSION))

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SRC := src/cs50.c
 INCLUDE := src/cs50.h
 MANS := $(wildcard docs/*.3.gz)
 
-CFLAGS=-Wall -Wextra -Werror -pedantic -std=c11 -O3
+CFLAGS=-Wall -Wextra -Wshadow -std=c11 -O3
 BASENAME=libcs50
 LIB_STATIC=$(BASENAME).a
 LIB_OBJ=$(BASENAME).o


### PR DESCRIPTION
As far as I can tell, currently when you install to a non-standard location, such as $HOME/.local, runtime linking will fail.

-install_name appears to need an absolute path.