### PR TITLE
Update copyright year

### DIFF
--- a/src/cs50.c
+++ b/src/cs50.c
@@ -4,7 +4,7 @@
  *
  * Based on Eric Roberts' genlib.c and simpio.c.
  *
- * Copyright (c) 2020
+ * Copyright (c) 2021
  * All rights reserved
  *
  * BSD 3-Clause License

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -4,7 +4,7 @@
  *
  * Based on Eric Roberts' genlib.c and simpio.c.
  *
- * Copyright (c) 2020
+ * Copyright (c) 2021
  * All rights reserved
  *
  * BSD 3-Clause License


### PR DESCRIPTION
This PR updates the copyright year from 2020 to 2021 on `cs50.h` and `cs50.c` files.