### PR TITLE
invalid conversion from 'void*' to 'char*' Error Fix

### DIFF
--- a/src/cs50.c
+++ b/src/cs50.c
@@ -144,7 +144,8 @@ string get_string(va_list *args, const char *format, ...)
             }
 
             // Extend buffer's capacity
-            string temp = realloc(buffer, capacity);
+            /*Adding the (string) cast to the realloc return value solves an error*/
+            string temp = (string) realloc(buffer, capacity);
             if (temp == NULL)
             {
                 free(buffer);
@@ -182,7 +183,8 @@ string get_string(va_list *args, const char *format, ...)
     }
 
     // Minimize buffer
-    string s = realloc(buffer, size + 1);
+    /*Adding the (string) cast to the realloc return value solves an error*/
+    string s = (string) realloc(buffer, size + 1);
     if (s == NULL)
     {
         free(buffer);
@@ -193,7 +195,8 @@ string get_string(va_list *args, const char *format, ...)
     s[size] = '\0';
 
     // Resize array so as to append string
-    string *tmp = realloc(strings, sizeof (string) * (allocations + 1));
+    /*Adding the (string*) cast to the realloc return value solves an error*/
+    string *tmp = (string*) realloc(strings, sizeof (string) * (allocations + 1));
     if (tmp == NULL)
     {
         free(s);


### PR DESCRIPTION
After successfully installing the cs50 library, and error popped up, i am using the mingw64 gcc compiler and also using the C/C++ extension for visual code. The error "invalid conversion from 'void*' to 'char**' [-fpermissive]" showed up 3 times, after further inspection i realized that this error was generated at the use of the function realloc, this function returns a pointer-to void (void*) value, and it was being assigned to a string, aka char*, value. Adding a simple cast to the realloc return value solves this issue.