### PR TITLE
Fix get_int Bug on this test

### DIFF
--- a/tests/get_int.c
+++ b/tests/get_int.c
@@ -3,7 +3,7 @@
 
 int main(void)
 {
-    int i = get_int();
+    int i = get_int("Enter a number:\n");
     printf("%i\n", i);
     int j = get_int("Foo: ");
     printf("%i\n", j);


### PR DESCRIPTION
in line  6:

get_int  parentheses should have any string
" int get_int(const char *format, ...) __attribute__((format(printf, 1, 2))); "

so, let's fix it...