### PR TITLE
Improved a slight inefficiency when reallocating

### DIFF
--- a/src/cs50.c
+++ b/src/cs50.c
@@ -135,7 +135,16 @@ string get_string(va_list *args, const char *format, ...)
             // Increment buffer's capacity if possible
             if (capacity < SIZE_MAX)
             {
-                capacity++;
+                // Try to accomodate possible extra characters
+                if (capacity == 0)
+                {
+                    capacity += 1;
+                }
+                else
+                {
+                    capacity = (size_t) round(capacity * 1.6);
+                } 
+
             }
             else
             {


### PR DESCRIPTION
The inefficiency lies at the repeated calling of realloc() to make space for each character read just for the buffer to be minimized at the end. 